### PR TITLE
Transaction history icons add

### DIFF
--- a/CommonWallet/Classes/Common/Views/TransactionCellViewModel.swift
+++ b/CommonWallet/Classes/Common/Views/TransactionCellViewModel.swift
@@ -11,6 +11,7 @@ public protocol TransactionItemViewModelProtocol: class {
     var title: String { get }
     var incoming: Bool { get }
     var status: AssetTransactionStatus { get }
+    var icon: UIImage? { get }
 }
 
 final class TransactionItemViewModel: TransactionItemViewModelProtocol {
@@ -19,6 +20,7 @@ final class TransactionItemViewModel: TransactionItemViewModelProtocol {
     var title: String = ""
     var incoming: Bool = false
     var status: AssetTransactionStatus = .commited
+    var icon: UIImage?
     
     init(transactionId: String) {
         self.transactionId = transactionId

--- a/CommonWallet/Classes/Common/Views/TransactionTableViewCell.swift
+++ b/CommonWallet/Classes/Common/Views/TransactionTableViewCell.swift
@@ -6,10 +6,17 @@
 import UIKit
 
 final class TransactionTableViewCell: UITableViewCell {
+    private struct Constants {
+        static let leadingEmptyImage: CGFloat = 20.0
+        static let leadingNonEmptyImage: CGFloat = 10.0
+    }
+
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private var amountLabel: UILabel!
     @IBOutlet private var signImageView: UIImageView!
     @IBOutlet private var statusImageView: UIImageView!
+    @IBOutlet private var titleLeading: NSLayoutConstraint!
+    private var iconImageView: UIImageView?
 
     private(set) var viewModel: TransactionItemViewModelProtocol?
 
@@ -42,6 +49,7 @@ final class TransactionTableViewCell: UITableViewCell {
             titleLabel.text = viewModel.title
             amountLabel.text = viewModel.amount
 
+            apply(icon: viewModel.icon)
             applyIncomingIcon()
             applyStatusStyle()
         }
@@ -83,5 +91,38 @@ final class TransactionTableViewCell: UITableViewCell {
             applyIncomingIcon()
             applyStatusStyle()
         }
+    }
+
+    private func apply(icon: UIImage?) {
+        if let icon = icon {
+            if iconImageView == nil {
+                let iconImageView = UIImageView()
+                iconImageView.translatesAutoresizingMaskIntoConstraints = false
+
+                contentView.addSubview(iconImageView)
+
+                let leading = iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
+                                                                     constant: Constants.leadingNonEmptyImage)
+                leading.isActive = true
+
+                let center = iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+                center.isActive = true
+
+                self.iconImageView = iconImageView
+            }
+
+            titleLeading.constant = icon.size.width + 2 * Constants.leadingNonEmptyImage
+
+            iconImageView?.image = icon
+        } else {
+            iconImageView?.removeFromSuperview()
+            iconImageView = nil
+
+            titleLeading.constant = Constants.leadingEmptyImage
+        }
+
+        var currentInsets = self.separatorInset
+        currentInsets.left = titleLeading.constant
+        self.separatorInset = currentInsets
     }
 }

--- a/CommonWallet/Classes/Common/Views/TransactionTableViewCell.xib
+++ b/CommonWallet/Classes/Common/Views/TransactionTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,17 +13,17 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="55"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7hk-4L-D2r" id="XdT-nR-d6s">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="54.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="55"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="John Smith" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TG3-mS-Pvf">
-                        <rect key="frame" x="20" y="19" width="291" height="16.5"/>
+                        <rect key="frame" x="20" y="19.5" width="291" height="16.5"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$500" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zho-iY-XHO">
-                        <rect key="frame" x="362.5" y="19" width="31.5" height="16.5"/>
+                        <rect key="frame" x="362.5" y="19.5" width="31.5" height="16.5"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -55,6 +53,7 @@
                 <outlet property="signImageView" destination="nCt-5W-raO" id="DbG-2X-vtX"/>
                 <outlet property="statusImageView" destination="PS0-6w-GuD" id="yCK-q7-uyG"/>
                 <outlet property="titleLabel" destination="TG3-mS-Pvf" id="u2A-dA-7Dg"/>
+                <outlet property="titleLeading" destination="rh7-yW-3vG" id="yF3-Tb-nGO"/>
             </connections>
             <point key="canvasLocation" x="-106" y="141"/>
         </tableViewCell>

--- a/CommonWallet/Classes/Modules/History/HistoryViewModelFactory.swift
+++ b/CommonWallet/Classes/Modules/History/HistoryViewModelFactory.swift
@@ -96,6 +96,7 @@ final class HistoryViewModelFactory {
 
         if let transactionType = transactionTypes[transaction.type] {
             viewModel.incoming = transactionType.isIncome
+            viewModel.icon = transactionType.typeIcon
         }
 
         if let asset = assets[transaction.assetId] {

--- a/Example/CommonWallet/Demo/Default/DefaultDemo.swift
+++ b/Example/CommonWallet/Demo/Default/DefaultDemo.swift
@@ -38,7 +38,7 @@ final class DefaultDemo: DemoFactoryProtocol {
         let withdrawType = WalletTransactionType(backendName: "WITHDRAW",
                                                  displayName: "Withdraw",
                                                  isIncome: false,
-                                                 typeIcon: nil)
+                                                 typeIcon: UIImage(named: "iconEth"))
 
         let walletBuilder =  CommonWalletBuilder
             .builder(with: account, networkResolver: networkResolver)


### PR DESCRIPTION
There is a necessity to display icons corresponding to transaction types in the history list. We already have an opportunity for a client to provide those icons. However previously there was no logic to display them. This pull request adds logic to the cell to display provided icons.