### PR TITLE
Add command to present transaction details

### DIFF
--- a/CommonWallet/Classes/Common/Commands/TransactionDetailsCommand.swift
+++ b/CommonWallet/Classes/Common/Commands/TransactionDetailsCommand.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+final class TransactionDetailsCommand: WalletPresentationCommandProtocol {
+    let transaction: AssetTransactionData
+    let resolver: ResolverProtocol
+
+    var presentationStyle: WalletPresentationStyle = .modal(inNavigation: true)
+    var animated: Bool = true
+
+    init(resolver: ResolverProtocol, transaction: AssetTransactionData) {
+        self.resolver = resolver
+        self.transaction = transaction
+    }
+
+    func execute() throws {
+        guard
+            let trasactionDetailsView = TransactionDetailsAssembly
+                .assembleView(resolver: resolver, transactionDetails: transaction),
+            let navigation = resolver.navigation else {
+            return
+        }
+
+        present(view: trasactionDetailsView.controller, in: navigation, animated: animated)
+    }
+}

--- a/CommonWallet/Classes/Common/Resolver/Resolver+Context.swift
+++ b/CommonWallet/Classes/Common/Resolver/Resolver+Context.swift
@@ -56,4 +56,8 @@ extension Resolver: CommonWalletContextProtocol {
     func prepareLanguageSwitchCommand(with newLanguage: WalletLanguage) -> WalletCommandProtocol {
         return LanguageSwitchCommand(resolver: self, language: newLanguage)
     }
+
+    func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol {
+        return TransactionDetailsCommand(resolver: self, transaction: transaction)
+    }
 }

--- a/CommonWallet/Classes/CommonWalletContext.swift
+++ b/CommonWallet/Classes/CommonWalletContext.swift
@@ -18,6 +18,7 @@ public protocol WalletCommandFactoryProtocol: class {
     func prepareHideCommand(with actionType: WalletHideActionType) -> WalletHideCommandProtocol
     func prepareAccountUpdateCommand() -> WalletCommandProtocol
     func prepareLanguageSwitchCommand(with newLanguage: WalletLanguage) -> WalletCommandProtocol
+    func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol
 }
 
 public protocol CommonWalletContextProtocol: WalletCommandFactoryProtocol {

--- a/CommonWallet/Classes/Modules/Amount/AmountPresenter.swift
+++ b/CommonWallet/Classes/Modules/Amount/AmountPresenter.swift
@@ -411,9 +411,10 @@ final class AmountPresenter {
                                                               sender: account.accountId,
                                                               receiver: payload.receiveInfo.accountId) else {
             let locale = localizationManager?.selectedLocale ?? Locale.current
+            let receiverId = payload.receiveInfo.accountId
             let message = transferViewModelFactory.createMinimumLimitErrorDetails(for: selectedAsset,
                                                                                   sender: account.accountId,
-                                                                                  receiver: payload.receiveInfo.accountId,
+                                                                                  receiver: receiverId,
                                                                                   locale: locale)
             view?.showError(message: message)
             return false

--- a/CommonWallet/Classes/Modules/History/HistoryCoordinator.swift
+++ b/CommonWallet/Classes/Modules/History/HistoryCoordinator.swift
@@ -15,14 +15,12 @@ final class HistoryCoordinator: HistoryCoordinatorProtocol {
     weak var delegate: HistoryCoordinatorDelegate?
 
     func presentDetails(for transaction: AssetTransactionData) {
-        guard let view = TransactionDetailsAssembly
-            .assembleView(resolver: resolver, transactionDetails: transaction) else {
-                return
+        do {
+            let command = resolver.commandFactory.prepareTransactionDetailsCommand(with: transaction)
+            try command.execute()
+        } catch {
+            resolver.logger?.error("Transaction details presentation failed: \(error)")
         }
-
-        view.controller.hidesBottomBarWhenPushed = true
-
-        resolver.navigation?.push(view.controller)
     }
     
     func presentFilter(filter: WalletHistoryRequest?, assets: [WalletAsset]) {

--- a/CommonWallet/Classes/Modules/TransactionDetails/TransactionDetailsCoordinator.swift
+++ b/CommonWallet/Classes/Modules/TransactionDetails/TransactionDetailsCoordinator.swift
@@ -19,6 +19,6 @@ final class TransactionDetailsCoordinator: TransactionDetailsCoordinatorProtocol
             return
         }
 
-        resolver.navigation?.present(amountView.controller, inNavigationController: true)
+        resolver.navigation?.push(amountView.controller, animated: true)
     }
 }

--- a/Tests/Mocks/CommonMocks.swift
+++ b/Tests/Mocks/CommonMocks.swift
@@ -3919,6 +3919,21 @@ public class MockWalletCommandFactoryProtocol: WalletCommandFactoryProtocol, Cuc
         
     }
     
+    
+    
+    public func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol {
+        
+    return cuckoo_manager.call("prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol",
+            parameters: (transaction),
+            escapingParameters: (transaction),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.prepareTransactionDetailsCommand(with: transaction))
+        
+    }
+    
 
 	public struct __StubbingProxy_WalletCommandFactoryProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -3971,6 +3986,11 @@ public class MockWalletCommandFactoryProtocol: WalletCommandFactoryProtocol, Cuc
 	    func prepareLanguageSwitchCommand<M1: Cuckoo.Matchable>(with newLanguage: M1) -> Cuckoo.ProtocolStubFunction<(WalletLanguage), WalletCommandProtocol> where M1.MatchedType == WalletLanguage {
 	        let matchers: [Cuckoo.ParameterMatcher<(WalletLanguage)>] = [wrap(matchable: newLanguage) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockWalletCommandFactoryProtocol.self, method: "prepareLanguageSwitchCommand(with: WalletLanguage) -> WalletCommandProtocol", parameterMatchers: matchers))
+	    }
+	    
+	    func prepareTransactionDetailsCommand<M1: Cuckoo.Matchable>(with transaction: M1) -> Cuckoo.ProtocolStubFunction<(AssetTransactionData), WalletPresentationCommandProtocol> where M1.MatchedType == AssetTransactionData {
+	        let matchers: [Cuckoo.ParameterMatcher<(AssetTransactionData)>] = [wrap(matchable: transaction) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockWalletCommandFactoryProtocol.self, method: "prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -4043,6 +4063,12 @@ public class MockWalletCommandFactoryProtocol: WalletCommandFactoryProtocol, Cuc
 	        return cuckoo_manager.verify("prepareLanguageSwitchCommand(with: WalletLanguage) -> WalletCommandProtocol", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
+	    @discardableResult
+	    func prepareTransactionDetailsCommand<M1: Cuckoo.Matchable>(with transaction: M1) -> Cuckoo.__DoNotUse<(AssetTransactionData), WalletPresentationCommandProtocol> where M1.MatchedType == AssetTransactionData {
+	        let matchers: [Cuckoo.ParameterMatcher<(AssetTransactionData)>] = [wrap(matchable: transaction) { $0 }]
+	        return cuckoo_manager.verify("prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
 	}
 }
 
@@ -4086,6 +4112,10 @@ public class WalletCommandFactoryProtocolStub: WalletCommandFactoryProtocol {
     
     public func prepareLanguageSwitchCommand(with newLanguage: WalletLanguage) -> WalletCommandProtocol  {
         return DefaultValueRegistry.defaultValue(for: (WalletCommandProtocol).self)
+    }
+    
+    public func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol  {
+        return DefaultValueRegistry.defaultValue(for: (WalletPresentationCommandProtocol).self)
     }
     
 }
@@ -4265,6 +4295,21 @@ public class MockCommonWalletContextProtocol: CommonWalletContextProtocol, Cucko
         
     }
     
+    
+    
+    public func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol {
+        
+    return cuckoo_manager.call("prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol",
+            parameters: (transaction),
+            escapingParameters: (transaction),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.prepareTransactionDetailsCommand(with: transaction))
+        
+    }
+    
 
 	public struct __StubbingProxy_CommonWalletContextProtocol: Cuckoo.StubbingProxy {
 	    private let cuckoo_manager: Cuckoo.MockManager
@@ -4322,6 +4367,11 @@ public class MockCommonWalletContextProtocol: CommonWalletContextProtocol, Cucko
 	    func prepareLanguageSwitchCommand<M1: Cuckoo.Matchable>(with newLanguage: M1) -> Cuckoo.ProtocolStubFunction<(WalletLanguage), WalletCommandProtocol> where M1.MatchedType == WalletLanguage {
 	        let matchers: [Cuckoo.ParameterMatcher<(WalletLanguage)>] = [wrap(matchable: newLanguage) { $0 }]
 	        return .init(stub: cuckoo_manager.createStub(for: MockCommonWalletContextProtocol.self, method: "prepareLanguageSwitchCommand(with: WalletLanguage) -> WalletCommandProtocol", parameterMatchers: matchers))
+	    }
+	    
+	    func prepareTransactionDetailsCommand<M1: Cuckoo.Matchable>(with transaction: M1) -> Cuckoo.ProtocolStubFunction<(AssetTransactionData), WalletPresentationCommandProtocol> where M1.MatchedType == AssetTransactionData {
+	        let matchers: [Cuckoo.ParameterMatcher<(AssetTransactionData)>] = [wrap(matchable: transaction) { $0 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockCommonWalletContextProtocol.self, method: "prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol", parameterMatchers: matchers))
 	    }
 	    
 	}
@@ -4400,6 +4450,12 @@ public class MockCommonWalletContextProtocol: CommonWalletContextProtocol, Cucko
 	        return cuckoo_manager.verify("prepareLanguageSwitchCommand(with: WalletLanguage) -> WalletCommandProtocol", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
 	    }
 	    
+	    @discardableResult
+	    func prepareTransactionDetailsCommand<M1: Cuckoo.Matchable>(with transaction: M1) -> Cuckoo.__DoNotUse<(AssetTransactionData), WalletPresentationCommandProtocol> where M1.MatchedType == AssetTransactionData {
+	        let matchers: [Cuckoo.ParameterMatcher<(AssetTransactionData)>] = [wrap(matchable: transaction) { $0 }]
+	        return cuckoo_manager.verify("prepareTransactionDetailsCommand(with: AssetTransactionData) -> WalletPresentationCommandProtocol", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
 	}
 }
 
@@ -4447,6 +4503,10 @@ public class CommonWalletContextProtocolStub: CommonWalletContextProtocol {
     
     public func prepareLanguageSwitchCommand(with newLanguage: WalletLanguage) -> WalletCommandProtocol  {
         return DefaultValueRegistry.defaultValue(for: (WalletCommandProtocol).self)
+    }
+    
+    public func prepareTransactionDetailsCommand(with transaction: AssetTransactionData) -> WalletPresentationCommandProtocol  {
+        return DefaultValueRegistry.defaultValue(for: (WalletPresentationCommandProtocol).self)
     }
     
 }


### PR DESCRIPTION
There is a requirement to present details for transaction opened though push notification. To support such use case corresponding command is added.